### PR TITLE
Bump natives version to latest 1660775568

### DIFF
--- a/jackz_vehicle_builder.lua
+++ b/jackz_vehicle_builder.lua
@@ -12,7 +12,7 @@ require('templates/common')
 --#P:TEMPLATE("_SOURCE")
 --#P:TEMPLATE("common")
 
-util.require_natives(1627063482)
+util.require_natives(1660775568)
 if SCRIPT_META_LIST then
     menu.divider(SCRIPT_META_LIST, "-- Credits --")
     menu.divider(SCRIPT_META_LIST, "hexarobi - Testing, Suggestions & Fixees")


### PR DESCRIPTION
Without this update trying to use the new Siren setting failes

```
[9/3/2022 8:05:10 AM] ...ppData\Roaming\Stand\Lua Scripts\lib\jackzvehiclelib.lua:260: attempt to call a nil value (field '_SET_SIREN_KEEP_ON')
stack traceback:
	...ppData\Roaming\Stand\Lua Scripts\lib\jackzvehiclelib.lua:260: in function 'jackzvehiclelib.ApplyToVehicle'
	[string "jackz_vehicle_builder.lua"]:2546: in function 'spawn_vehicle'
	[string "jackz_vehicle_builder.lua"]:2848: in function 'add_attachments'
	[string "jackz_vehicle_builder.lua"]:2747: in function 'spawn_build'
	[string "jackz_vehicle_builder.lua"]:988: in function <[string "jackz_vehicle_builder.lua"]:985>
	[C]: in function 'xpcall'
	[string "--[[Stand Lua Runtime]]--..."]:18: in function 'Stand_internal_xpcall'
	[string "--[[Stand Lua Runtime]]--..."]:24: in function <[string "--[[Stand Lua Runtime]]--..."]:23>
```