### PR TITLE
Fix error when loading with stale lib

### DIFF
--- a/jackz_vehicle_builder.lua
+++ b/jackz_vehicle_builder.lua
@@ -27,7 +27,7 @@ end
 
 if vehiclelib.LIB_VERSION ~= VEHICLELIB_TARGET_VERSION then
     if SCRIPT_SOURCE == "MANUAL" then
-        log("jackzvehiclelib current: " .. vehiclelib.LIB_VERSION, ", target version: " .. VEHICLELIB_TARGET_VERSION)
+        util.log("jackzvehiclelib current: " .. vehiclelib.LIB_VERSION, ", target version: " .. VEHICLELIB_TARGET_VERSION)
         util.toast("Outdated vehiclelib library, downloading update...")
         download_lib_update("jackzvehiclelib.lua")
         vehiclelib = require("jackzvehiclelib")


### PR DESCRIPTION
Looks like the `log()` function isnt defined yet with this triggers, so throws an error. Change it to just a regular `util.log()` to avoid.